### PR TITLE
Replaced DNS_ALL with DNS_ANY as many servers hang on DNS_ALL

### DIFF
--- a/src/Helpers/Utils.php
+++ b/src/Helpers/Utils.php
@@ -20,7 +20,7 @@ class Utils {
     public static function getallRecords($query) {
 
         //assign a variable for the dns lookup
-        $dnsData = dns_get_record($query, DNS_ALL);
+        $dnsData = dns_get_record($query, DNS_ANY);
 
         //return the dns results
         return $dnsData;


### PR DESCRIPTION
Hi,

After some investigation we've found that `DNS_ALL` on many systems do not work reliably, e.g. 2 demo services:

- https://odin2.stormcreative.co.uk/test.php (Linode)
- https://odin.stormcreative.co.uk/test.php (Digital Ocean)

You can see that `DNS_ANY` works but `DNS_ALL` errors.

The code used is:

```php
<?php
var_dump(dns_get_record('google.com', DNS_ANY));
var_dump(dns_get_record('google.com', DNS_ALL));
```

Replacing the above code causes the error to resolve